### PR TITLE
Local Testing: functions.https.onRequest(req, res)

### DIFF
--- a/middleware.min.js
+++ b/middleware.min.js
@@ -30,7 +30,6 @@ const { Readable, Writable } = require('stream');
 
 
 function moveRaw(req, res, next) {
-    var s;
     if (req.body && !req.rawBody && req.method == 'POST') {
         console.log('moveRaw pip pi');
         const buf = [];
@@ -62,7 +61,6 @@ function busboy(req, res, next) {
     var fields = {};
     const uploads = {};
     const objects = {};
-    const { Canvas, Image, ImageAsync } = require('./image-maker/Canvas.js');
     try {
         if (req.method == 'POST') {
             console.log(req.headers);

--- a/middleware.min.js
+++ b/middleware.min.js
@@ -1,0 +1,188 @@
+﻿/*
+ * Topic: functions.https.onRequest(req, res)
+ * What: Adding middleware to make local test environment behave the same as a deployed function  
+ * Proposed usecase: multipart/form-data, but not only
+ * 
+ * */
+
+const http = require('http');
+const express = require('express');
+const app = express();
+const path = require('path');
+const os = require('os');
+const tmpdir = os.tmpdir();
+const fs = require('fs');
+const Busboy = require('busboy');
+const { inspect } = require('util');
+const cors = require('cors');
+const bodyParser = require('body-parser');
+const { Readable, Writable } = require('stream');
+/*
+ * These modules are not comptible with the built-in middleware of Cloud Functions:
+ * 
+ * const multer = require('multer');
+ * const upload = multer();
+ * const formidable = require('formidable');
+ * 
+ * They will work on local environments!
+ * 
+ * */
+
+
+function moveRaw(req, res, next) {
+    var s;
+    if (req.body && !req.rawBody && req.method == 'POST') {
+        console.log('moveRaw pip pi');
+        const buf = [];
+        req.on('data', function (chunk) {
+            //console.log(chunk);
+            buf.push(chunk);
+            //next();
+        });
+        req.on('error', function (error) {
+            console.log(error)
+            next(err);
+        });
+        req.on('end', function () {
+            console.log('body streamed to rawBody');
+            const buffer = Buffer.concat(buf);
+            req.rawBody = buffer;
+            //req.body = buffer;
+            next();
+        });
+    }
+    else {
+        next();
+    }
+}
+
+function busboy(req, res, next) {
+    req.files = [];
+    req.fields = {};
+    var fields = {};
+    const uploads = {};
+    const objects = {};
+    const { Canvas, Image, ImageAsync } = require('./image-maker/Canvas.js');
+    try {
+        if (req.method == 'POST') {
+            console.log(req.headers);
+            var busboy = new Busboy({ headers: req.headers, defCharset: 'utf-8' });
+
+            busboy.on('file', function (fieldname, file, filename, encoding, mimetype) {
+                console.log('File [' + fieldname + ']: filename: ' + filename + ', encoding: ' + encoding + ', mimetype: ' + mimetype);
+                const filepath = path.join(tmpdir, filename);
+                const writer = fs.createWriteStream(filepath)
+                    .on('write', function (chunk, encoding, next) {
+                        next();
+                    })
+
+                file.on('data', function (data) {
+                    console.log('File [' + fieldname + '] got ' + data.length + ' bytes');
+                });
+                file.on('end', function () {
+                    console.log('File [' + fieldname + '] Finished');
+                    uploads[fieldname] = filepath;
+                    objects[fieldname] = {
+                        field: fieldname,
+                        name: filename,
+                        encoding: encoding,
+                        mimetype: mimetype,
+                        tempPath: filepath
+                    }
+                });
+                /*
+                 * Pipe file to /tmp (=os.tmpdir()), which is the functions tmp file.
+                 * Contents of /tmp are not to be considered available after the function completed execution.
+                 * 
+                 * When testing locally be careful with this because if you stream a file to os.tmpdir() 
+                 * it will remain there until you unlink it using fs.unlink($filename).
+                 * This is why it is good practice to unlink all file before function terminates
+                 * Another good PR to add to local emulation!
+                 * 
+                 * /tmp is also reffered in documentation as /tmpfs
+                 * 
+                 * another consideration to be made is the function's allocated memory.
+                 * This can be handled in GCP in the Cloud Functions dashboard by choosing a function and clicking EDIT.
+                 * When emulating locally this is not a problem but after deployment the function might crash with code: 
+                 * Error: memory limit exceeded. Function invocation was interrupted.
+                 * 
+                 * */
+                file.pipe(writer);  
+            });
+            busboy.on('field', function (fieldname, val, fieldnameTruncated, valTruncated, encoding, mimetype) {
+                console.log('Field [' + fieldname + ']: value: ' + inspect(val));
+
+                fields[fieldname] = val;
+            });
+            busboy.on('finish', function () {
+                for (var field in fields) {
+                    try {
+                        var val = JSON.parse(fields[field]);
+                        fields[field] = val;
+                    }
+                    catch (err) {
+                        console.log(err);
+                    }
+                }
+                for (var file in objects) {
+                    req.files.push(objects[file]);
+                }
+                Object.assign(req, { fields });
+                console.log(req.fields);
+                console.log(req.files);
+                console.log('Done parsing form!');
+                next();
+            });
+
+            var s;
+            if (req.rawBody) {
+                console.log('busboy: Has req.rawBody')
+                s = new Readable();
+                s._read = function noop() { };
+                s.push(req.rawBody);
+                s.push(null);
+            }
+            else {
+                //for test environment not using Function: moveRaw
+                console.log('busboy: NO req.rawBody')
+                s = req;
+            }
+            s.pipe(busboy);
+        }
+        else {
+            console.log('skipped busboy');
+            next();
+        }
+    }
+    catch (err) {
+        console.log(err);
+        next();
+    }
+}
+
+app.use(moveRaw);
+app.use(bodyParser.raw());
+/*
+ * app.use(bodyParser.text());
+ * app.use(bodyParser.json()); // for parsing application/json
+ * app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
+ * */
+
+/*
+ * 
+ * The middleware up to here parses a request made by a local server (CLI: $ firebase serve)
+ * making it indentical to requests recieved by a deployed function.
+ * Without it middleware modules will work on a local server and fail after deployment.
+ * */
+
+
+//
+app.use(cors({ origin: true }));
+
+/*
+ * Parse multipart/form-data etc.
+ * busboy is a good option because you can specify the data to pipe to it, making it usable with cloud functions.
+ * multer and formidable aren't suitable for use with cloud functions due to this reason.
+ * They take the entire req and parse it, but by the time the request gets to them the req is parsed or empty.
+ * */
+app.use(busboy); 


### PR DESCRIPTION
Adding middleware to make local testing of HTTPS functions behave the same as deployed functions.
Usecase example: sending multipart/form-data to a cloud function.
Proposed Change: Commit middleware as built-in part of the local emulator


-- couldn't find a better place to make the PR